### PR TITLE
Added default multi-platform builds for amd64 and arm64 docker images.

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -1,4 +1,3 @@
----
 name: "Build Docker Image"
 description: "Build Docker image for arbitrary revision/branch/tag and push to registry"
 
@@ -6,6 +5,9 @@ inputs:
   tag:
     description: Revision, tag, or branch to build
     required: true
+    default: ${{ github.event.repository.default_branch }}
+  img_tag:
+    description: Tag applied to the container image.
   image:
     description: >-
       Image to build, e.g. ghcr.io/organization/image.
@@ -16,13 +18,11 @@ inputs:
     default: ghcr.io
   registry_username:
     description: >-
-      Username for logging in to registry. For GHCR (and by default),
-      set to github.actor.
+      Username for logging in to registry. For GHCR (and by default), set to github.actor.
     default: ${{ github.actor }}
   registry_token:
     description: >-
-      Token for logging in to registry.  For GHCR (and by default),
-      set to github.token.
+      Token for logging in to registry.  For GHCR (and by default), set to github.token.
     default: ${{ github.token }}
   build-args:
     description: >-
@@ -38,72 +38,107 @@ inputs:
     default: false
   submodules:
     description: >-
-      Whether to checkout submodules (as for actions@v3) and thence build them
-      into the image. Set to false by default as for checkout. If you use submodules,
-      you probably want to set this.
+      Whether to checkout submodules (as for actions@v3) and thence build them into the image. Set to false by default as for checkout. If you use submodules, you probably want to set this.
     default: false
+  platforms:
+    description: >-
+      Build images for cross platform support.
+    default: "linux/amd64,linux/arm64"
+  rebuild:
+    description: Rebuild the image manually?
+    default: false
+  gh_event:
+    description: The name of the event that triggered the parent workflow.
 
 runs:
   using: composite
   steps:
-    - name: Clone latest repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.tag }}
-        submodules: ${{ inputs.submodules }}
-
-    - name: Find commit for tag
-      id: tag_check
-      uses: hathitrust/github_actions/validate-tag@v1
-      with:
-        tag: ${{ inputs.tag }}
-
-    - name: Log into container registry
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.registry_username }}
-        password: ${{ inputs.registry_token }}
-
-    - name: Check if revision exists in container registry
-      id: image_check
-      shell: bash
-      run: |
-        echo Checking whether Docker image "$IMAGE":"$TAG" exists
-        if docker manifest inspect "$IMAGE":"$TAG" > /dev/null; then
-          echo 'image_exists=true' >> $GITHUB_OUTPUT
-          echo "image exists!"
+  - name: Set Inputs & Outputs
+    id: set_inputs
+    shell: bash
+    run: |
+      if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "push_latest=true" >> $GITHUB_OUTPUT
         else
-          echo "image doesn't exist; Starting to Build and push image"
+            # workflow_dispatch or other trigger
+            echo "ref=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "push_latest=${{ inputs.push_latest }}" >> $GITHUB_OUTPUT
+            echo "img_tag=${{ inputs.img_tag }}" >> $GITHUB_OUTPUT
         fi
-      env:
-        IMAGE: ${{ inputs.image }}
-        TAG: ${{ steps.tag_check.outputs.tag }}
 
-    - name: Check whether to push latest tag
-      if: ${{ steps.image_check.outputs.image_exists != 'true' }}
-      id: latest_push
-      uses: actions/github-script@v6
-      env:
-        INPUT_PUSH_LATEST: ${{ inputs.push_latest }}
-        INPUT_IMAGE: ${{ inputs.image }}
-      with:
-        script: |
-          if ( core.getInput('push_latest') == 'true' ) {
-            core.setOutput('latest_tag',core.getInput('image') + ':latest')
-          } else {
-            core.setOutput('latest_tag','')
-          }
+  - name: Clone latest repository
+    uses: actions/checkout@v4
+    with:
+      ref: ${{ steps.set_inputs.outputs.ref }}
+      submodules: ${{ inputs.submodules }}
 
-    - name: Build image and push to GHCR
-      if: ${{ steps.image_check.outputs.image_exists != 'true' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        push: true
-        tags: |
-          ${{ inputs.image }}:${{ inputs.tag }}
-          ${{ inputs.image }}:${{ steps.tag_check.outputs.tag }}
-          ${{ steps.latest_push.outputs.latest_tag }}
-        file: ${{ inputs.dockerfile }}
-        build-args: ${{ inputs.build-args }}
+  - name: Find commit for tag
+    id: tag_check
+    uses: hathitrust/github_actions/validate-tag@v1
+    with:
+      tag: ${{ steps.set_inputs.outputs.ref }}
+
+  - name: Log into container registry
+    uses: docker/login-action@v3
+    with:
+      registry: ${{ inputs.registry }}
+      username: ${{ inputs.registry_username }}
+      password: ${{ inputs.registry_token }}
+
+  - name: Check if revision exists in container registry
+    id: image_check
+    shell: bash
+    run: |
+      echo Checking whether Docker image "$IMAGE":"$TAG" exists
+      if docker manifest inspect "$IMAGE":"$TAG" > /dev/null; then
+        echo 'image_exists=true' >> $GITHUB_OUTPUT
+        echo "image exists!"
+      else
+        echo "image doesn't exist; Starting to Build and push image"
+      fi
+    env:
+      IMAGE: ${{ inputs.image }}
+      TAG: ${{ steps.tag_check.outputs.tag }}
+
+  - name: Check whether to push latest tag
+    if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
+    id: latest_push
+    uses: actions/github-script@v7
+    env:
+      INPUT_PUSH_LATEST: ${{ steps.set_inputs.outputs.push_latest }}
+      INPUT_IMAGE: ${{ inputs.image }}
+    with:
+      script: |
+        if ( core.getInput('push_latest') == 'true' ) {
+          core.setOutput('latest_tag',core.getInput('image') + ':latest')
+        } else {
+          core.setOutput('latest_tag',core.getInput('image') + ':unstable')
+        }
+
+  - name: Set up QEMU
+    if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
+    # QEMU emulation for the Arm portion of our multi-platform Docker image build. Intel Machines
+    uses: docker/setup-qemu-action@v3
+
+  - name: Set up Docker Buildx
+    if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
+    # Required for multi-platform Docker image builds in GitHub Actions that use docker/build-push-action.
+    uses: docker/setup-buildx-action@v3
+
+  - name: Build image and push to GHCR
+    if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
+    uses: docker/build-push-action@v5
+    with:
+      context: .
+      push: true
+      tags: |
+        ${{ inputs.image }}:${{ steps.set_inputs.outputs.img_tag && inputs.img_tag || steps.tag_check.outputs.tag }}
+        ${{ inputs.image }}:${{ steps.tag_check.outputs.tag }}
+        ${{ steps.latest_push.outputs.latest_tag }}
+      file: ${{ inputs.dockerfile }}
+      build-args: ${{ inputs.build-args }}
+      platforms: ${{ inputs.platforms}}
+      cache-from: type=gha
+      cache-to: type=gha,mode=max
+      provenance: false


### PR DESCRIPTION
The way this branch currently works is that there are two default platforms it will build; both ARM64 and AMD64 images. The `platforms` argument may be omitted from the parent job that calls this composite action and it will still generate those images. 