### PR TITLE
GH shared actions dependency updates

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -75,7 +75,7 @@ runs:
         fi
 
   - name: Clone latest repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
     with:
       ref: ${{ steps.set_inputs.outputs.ref }}
       submodules: ${{ inputs.submodules }}
@@ -87,7 +87,7 @@ runs:
       tag: ${{ steps.set_inputs.outputs.ref }}
 
   - name: Log into container registry
-    uses: docker/login-action@v3
+    uses: docker/login-action@v4
     with:
       registry: ${{ inputs.registry }}
       username: ${{ inputs.registry_username }}
@@ -111,7 +111,7 @@ runs:
   - name: Check whether to push latest tag
     if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
     id: latest_push
-    uses: actions/github-script@v7
+    uses: actions/github-script@v9
     env:
       INPUT_PUSH_LATEST: ${{ steps.set_inputs.outputs.push_latest }}
       INPUT_IMAGE: ${{ inputs.image }}
@@ -126,16 +126,16 @@ runs:
   - name: Set up QEMU
     if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
     # QEMU emulation for the Arm portion of our multi-platform Docker image build. Intel Machines
-    uses: docker/setup-qemu-action@v3
+    uses: docker/setup-qemu-action@v4
 
   - name: Set up Docker Buildx
     if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
     # Required for multi-platform Docker image builds in GitHub Actions that use docker/build-push-action.
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@v4
 
   - name: Build image and push to GHCR
     if: ${{ steps.image_check.outputs.image_exists != 'true' || inputs.rebuild }}
-    uses: docker/build-push-action@v5
+    uses: docker/build-push-action@v7
     with:
       context: .
       push: true

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
     with:
       fetch-depth: 0
   - name: Set environment variables
@@ -52,13 +52,13 @@ runs:
       fi
   - name: Generate app token
     id: generate_token
-    uses: actions/create-github-app-token@v1
+    uses: actions/create-github-app-token@v3
     with:
       app-id: ${{ env.CONFIG_REPO_RW_APP_ID }}
       private-key: ${{ inputs.CONFIG_REPO_RW_KEY }}
       owner: ${{ github.repository_owner }}
   - name: Send the message
-    uses: peter-evans/repository-dispatch@v3
+    uses: actions/create-github-app-token@v4
     with:
       event-type: update-image
       token: ${{ steps.generate_token.outputs.token }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -58,7 +58,7 @@ runs:
       private-key: ${{ inputs.CONFIG_REPO_RW_KEY }}
       owner: ${{ github.repository_owner }}
   - name: Send the message
-    uses: actions/create-github-app-token@v4
+    uses: peter-evans/repository-dispatch@v4
     with:
       event-type: update-image
       token: ${{ steps.generate_token.outputs.token }}

--- a/scan-image/action.yml
+++ b/scan-image/action.yml
@@ -44,7 +44,7 @@ runs:
 
   - name: Comment on PR
     if: github.event_name == 'pull_request'
-    uses: actions/github-script@v7
+    uses: actions/github-script@v9
     with:
       script: |
         const fs = require('fs')

--- a/tag-release/action.yml
+++ b/tag-release/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
   - name: Log into container registry
-    uses: docker/login-action@v3
+    uses: docker/login-action@v4
     with:
       registry: ${{ inputs.registry }}
       username: ${{ inputs.registry_username }}

--- a/update-image/action.yml
+++ b/update-image/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
   - name: Clone latest repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
   - name: dump github event
     shell: bash
     env:


### PR DESCRIPTION
- actions/checkout@**v4** to **v6**
- docker/login-action@**v3** to **v4**
- actions/github-script@**v7** to **v9**
- docker/setup-qemu-action@**v3** to **v4**
- docker/setup-buildx-action@**v3** to **v4**
- docker/build-push-action@**v5** to **v7**
- actions/create-github-app-token@**v1** to **v3**
- > Note: No breaking changes but `app_id` is being marked as deprecated and set to use `client_id` instead but `app_id` is set to be a fall back option. https://github.com/actions/create-github-app-token/compare/v3.0.0...v3.1.0
- peter-evans/repository-dispatch@**v3** to **v4**